### PR TITLE
l10ns set was crashing 'ref is undefined'

### DIFF
--- a/libraries/set.js
+++ b/libraries/set.js
@@ -125,7 +125,7 @@ Set.prototype._getKey = function(reference) {
     });
   }
   else {
-    deferred.resolve(ref);
+    deferred.resolve(reference);
   }
 
   return deferred.promise;


### PR DESCRIPTION
when calling `l10ns set SOME__KEY -l es-EC "Some Value"`