### PR TITLE
Optional region

### DIFF
--- a/libraries/MessageFormat/index.js
+++ b/libraries/MessageFormat/index.js
@@ -29,8 +29,8 @@ function MessageFormat(locale) {
   else {
     this.languageModifier = null;
   }
-  this.language = /^([a-z]+)\-/.exec(this.locale)[1];
-  this.region = /\-([A-Z]+)$/.exec(this.locale)[1];
+  this.language = /^([a-z]+)\-?/.exec(this.locale)[1];
+  this.region = (/\-([A-Z]+)$/.exec(this.locale) || [])[1];
   this.variables = null;
   this.pluralRules = {};
   this.ordinalRules = {};


### PR DESCRIPTION
without this, MessageFormat would crash when the regex.exec returned null


FYI my wider motivation is I have a simple English/Spanish project and I want to keep it simple and just deal with "en" and "es" locales because we're not going to be localizing to region-specific (probably).