### PR TITLE
correct docs for plural exact form

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -469,7 +469,7 @@ We can also specify exact cases. Instead of using the plural forms. Notice: the 
 </p>
 
 <code>
-There {files, plural, 0={are no files} one{is one file} other{are many files}}.
+There {files, plural, =0{are no files} one{is one file} other{are many files}}.
 </code>
 
 <p>


### PR DESCRIPTION
message format for plural form take the exact form in the format `=n{` not `n={`