### PR TITLE
Updated error messages to correct exact format

### DIFF
--- a/libraries/MessageFormat/index.js
+++ b/libraries/MessageFormat/index.js
@@ -687,7 +687,7 @@ MessageFormat.prototype._parsePluralFormat = function(variable) {
         throw new TypeError('There must exist one other case in ' + this.lexer.getLatestTokensLog());
       }
       else {
-        throw new TypeError('Expected a keyword (' + pluralKeywords.join(', ')+ ') or an exact case (n=). Instead got \'' + _case + '\' in ' + this.lexer.getLatestTokensLog());
+        throw new TypeError('Expected a keyword (' + pluralKeywords.join(', ')+ ') or an exact case (=n). Instead got \'' + _case + '\' in ' + this.lexer.getLatestTokensLog());
       }
     }
   }
@@ -752,7 +752,7 @@ MessageFormat.prototype._parseSelectordinalFormat = function(variable) {
         throw new TypeError('There must exist one other case in ' + this.lexer.getLatestTokensLog());
       }
       else {
-        throw new TypeError('Expected a keyword (' + ordinalKeywords.join(', ')+ ') or an exact case (n=). Instead got \'' + _case + '\' in ' + this.lexer.getLatestTokensLog());
+        throw new TypeError('Expected a keyword (' + ordinalKeywords.join(', ')+ ') or an exact case (=n). Instead got \'' + _case + '\' in ' + this.lexer.getLatestTokensLog());
       }
     }
   }


### PR DESCRIPTION
messageFormat works with `=n`. It throws an error with the `n=` format. This commit fixes the error message to suggest the correct solution, and reduce confusion.