### PR TITLE
Store single string messages as simple string instead of function.

### DIFF
--- a/plugins/javascript/compiler.js
+++ b/plugins/javascript/compiler.js
@@ -253,12 +253,19 @@ Compiler.prototype._getLocalizationMap = function() {
         var localizationsCount = 0;
         for(var key in localizations[language]) {
           messageFormat.parse(localizations[language][key].value);
-          var _function = template['Function']({
-            functionBody: _this._indentSpaces(
-              2,
-              _this._getFunctionBody(messageFormat.messageAST, language)
-            )
-          });
+          var _function;
+	  if (messageFormat.messageAST.length === 1 && messageFormat.messageAST[0] instanceof MessageFormat.AST.Sentence) {
+            _function = '\'' + messageFormat.messageAST[0].string
+              .replace(/'/g, '\\\'')
+              .replace(/\n/g, '\\n') + '\'';
+          } else { 
+             _function = template['Function']({
+              functionBody: _this._indentSpaces(
+                2,
+                _this._getFunctionBody(messageFormat.messageAST, language)
+              )
+            });
+          }
 
           localizationMap += template['LocalizationKeyValue']({
             key: key,

--- a/plugins/javascript/templates/LocalizationGetter.tmpl
+++ b/plugins/javascript/templates/LocalizationGetter.tmpl
@@ -2,5 +2,10 @@ function l(key) {
   if(!(key in localizations['{{=it.language}}'])) {
     throw new TypeError('Key `' + key + '` not in {{=it.language}} localizations');
   }
-  return localizations['{{=it.language}}'][key].call(localizations['{{=it.language}}'], arguments[1]);
+  var loc = localizations['{{=it.language}}'][key];
+  if ( typeof loc === 'function' ) {
+    return loc.call(localizations['{{=it.language}}'], arguments[1]);
+  } else {
+    return loc;
+  }
 }


### PR DESCRIPTION
Warning: Breaks Testcases!

This stores single line, no variables translation objects more efficiently in the final js output. 

This is not production quality though, since im not too familiar with the testing framework.  It breaks some testcases and could have other side effects, but maybe  this is usefull as input for your own implementation.

```javascript
// Old
{
 'TEST': function(it) {
        var string = '';
        string += 'Test';
        return string;
      }
}
// New
{ 
  'TEST' : 'Test'
}
```

