### PR TITLE
Fix binary to support project flag properly

### DIFF
--- a/binaries/l10ns
+++ b/binaries/l10ns
@@ -77,7 +77,7 @@ commands
   .option('-e, --empty', 'only empty localizations')
   .option('-o, --open', 'open interface in browser')
   .option('--stack', 'with stack trace')
-  .option('-p, --project', 'specify project')
+  .option('-p, --project <project>', 'specify project')
 
 commands
   .command('init')


### PR DESCRIPTION
If you used the project flag and defined a project to use, he would fail to select the project and assume the project was ```undefined```.

Example:
![captura de ecra 2015-07-5 as 21 24 57](https://cloud.githubusercontent.com/assets/1002056/8513296/5e2d9820-235c-11e5-9528-439b454b82a9.png)